### PR TITLE
Improved BLOB support

### DIFF
--- a/pypxlib/__init__.py
+++ b/pypxlib/__init__.py
@@ -110,7 +110,7 @@ class Field(object):
 			return DoubleField(index, type_)
 		if type_ == pxfLogical:
 			return LogicalField(index, type_)
-		if type_ in (pxfBLOb, pxfMemoBLOb, pxfMemoBLOb, pxfBCD, pxfBytes):
+		if type_ in (pxfBLOb, pxfMemoBLOb, pxfBCD, pxfBytes):
 			return BytesField(index, type_)
 		if type_ in (pxfOLE, pxfGraphic):
 			return BytesField(index, type_)

--- a/pypxlib/__init__.py
+++ b/pypxlib/__init__.py
@@ -35,14 +35,15 @@ class Table(object):
 
 		# BLOB Support
 		# http://pxlib.sourceforge.net/documentation.php?manpage=PX_set_blob_file
-		if not self.blob_file_path:
+		if not blob_file_path:
 			# If not blob_file_path given, we try to acces automatically the related MB file
 			possible_blob_file = str(file_path).replace('.db', '.mb').replace('.DB', '.MB')
 			if os.path.isfile(possible_blob_file):
+				blob_file_path = possible_blob_file
 				self.blob_file_path = blob_file_path
 
 		# If given blob_file_path or file was automatically found we try to open it
-		if self.blob_file_path and PX_set_blob_file(self.pxdoc, blob_file_path.encode(self.PX_ENCODING)) < 0:
+		if blob_file_path and PX_set_blob_file(self.pxdoc, blob_file_path.encode(self.PX_ENCODING)) < 0:
 			raise PXError('Could not open BLOB file %s.' % self.blob_file_path)
 
 		self._fields_cached = None
@@ -200,8 +201,7 @@ class BytesField(Field):
 			return pxval_value.str.val[:pxval_value.str.len]
 		except:
 			# TODO - Change hardcoded enconding. Consider use the encoding parameter of Table __init__
-			return pxval_value.str.val.data.decode('cp850')
-
+			return pxval_value.str.val.data
 	def _serialize_to(self, value, pxval_value):
 		pxval_value.str.val = value
 		pxval_value.str.len = len(value)


### PR DESCRIPTION
# Added External BLOB files support

> Now **BytesFields** are deserialized as **non-binary strings.**
## Description

As you may now, independently from the .DB files there may be some .MB files containing BLOB's data. I added a new optional argument to the Table init to set explicitly that file. In case that file is not declared, it will try to find it by replacing the .db extension to .mb.

That way current users of the library **don't need to change anything** and they're able to access blob/memo data.

As Fields are independent from the Table object, I didn't found an easy approach to avoid hardcoding the encoding, so I put a _TODO_ there. Also I warped the legacy code of the BytesField deserialize function into a try-catch block to prevent failing existing solutions.
## Related documentation:
### Setting the BLOB file
- http://pxlib.sourceforge.net/documentation.php?manpage=PX_set_blob_file
### Reading the field
- http://pxlib.sourceforge.net/documentation.php?manpage=PX_retrieve_record
- http://pxlib.sourceforge.net/documentation.php?manpage=PX_read_blobdata [**DEPRECATED**]
- http://pxlib.sourceforge.net/documentation.php?manpage=PX_get_data_blob [**DEPRECATED**]
