### PR TITLE
Fix ValueError on NULL time fields

### DIFF
--- a/pypxlib/__init__.py
+++ b/pypxlib/__init__.py
@@ -7,6 +7,7 @@ import atexit
 
 PX_boot()
 atexit.register(PX_shutdown)
+NULL = -2147483648  # integer value that represents a NULL in PDOX
 
 class Table(object):
 
@@ -214,6 +215,8 @@ class TimeField(Field):
 		return cls._deserialize_ms(pxval_value.lval)
 	@classmethod
 	def _deserialize_ms(cls, ms_since_midnight):
+		if ms_since_midnight == NULL:
+			return None
 		ms = ms_since_midnight % 1000
 		seconds_since_midnight = ms_since_midnight // 1000
 		seconds = seconds_since_midnight % 60


### PR DESCRIPTION
Prevent ValueError on NULL time fields.  Fixes #17